### PR TITLE
fix: add required permissions to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,11 @@ jobs:
     name: Analyze Code Security
     runs-on: ubuntu-latest
     
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add security-events: write permission to fix CodeQL Action API access error. This allows the workflow to upload security analysis results to GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security permissions configuration for automated code analysis workflows to enforce principle of least privilege.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->