### PR TITLE
ci: fix versioning by disabling CI mode in get-version script

### DIFF
--- a/.github/scripts/get-version.js
+++ b/.github/scripts/get-version.js
@@ -20,6 +20,7 @@ async function run() {
 
       result = await semanticRelease({
         dryRun: true,
+        ci: false,
         branches: ['main'],
         plugins: [
           '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## Summary

This PR fixes the versioning script by explicitly disabling CI mode in semantic-release.

### Changes

- Added `ci: false` option to `semanticRelease()` configuration in `.github/scripts/get-version.js`

### Rationale

When running semantic-release in dry-run mode within GitHub Actions, the CI environment detection can interfere with version calculation. Setting `ci: false` ensures the version is computed correctly without CI-specific behaviors affecting the dry-run output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->