### PR TITLE
ci: remove unnecessary GITHUB_TOKEN from get-version step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Get next version
         id: get_version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(node .github/scripts/get-version.js)
           if [ -n "$VERSION" ]; then


### PR DESCRIPTION
## Summary

Removes the unnecessary GITHUB_TOKEN environment variable from the Get next version step in the build workflow.

## Problem

The GITHUB_TOKEN was causing semantic-release to run in CI mode, which was not the desired behavior for this step.

## Changes

- Removed env section with GITHUB_TOKEN from the Get next version step in .github/workflows/build.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build workflow configuration to streamline the version preparation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->