### PR TITLE
fix: change workflow permissions from read to write

### DIFF
--- a/.github/scripts/get-version.js
+++ b/.github/scripts/get-version.js
@@ -20,7 +20,6 @@ async function run() {
 
       result = await semanticRelease({
         dryRun: true,
-        ci: false,
         branches: ['main'],
         plugins: [
           '@semantic-release/commit-analyzer',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
-      contents: read
+      contents: write
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Get next version
         id: get_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(node .github/scripts/get-version.js)
           if [ -n "$VERSION" ]; then


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow permissions by changing `contents: read` to `contents: write` to allow the workflow to write releases/artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions and environment setup for release/version steps.
  * Adjusted release helper behavior to rely on default CI detection.
  
---

*Note: Infrastructure updates only; no user-facing functionality changes.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->