### PR TITLE
build: configure universal architecture for macOS builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,19 @@
     ],
     "mac": {
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": ["universal"]
+        }, {
+          "target": "zip",
+          "arch": ["universal"]
+        }
       ],
       "category": "public.app-category.utilities",
       "icon": "logo.png",
       "hardenedRuntime": true,
-      "gatekeeperAssess": false
+      "gatekeeperAssess": false,
+      "minimumSystemVersion": "14.0"
     },
     "win": {
       "target": [


### PR DESCRIPTION
## Summary
- Configures DMG and ZIP build targets to use universal architecture for macOS (supporting both Intel and Apple Silicon)
- Adds minimum system version requirement of macOS 14.0 for better compatibility

## Changes
- Updated `package.json` electron-builder configuration
- DMG and ZIP targets now explicitly specify `arch: ["universal"]`
- Added `minimumSystemVersion: "14.0"` for macOS builds

This change ensures the application builds are compatible with both Intel-based and Apple Silicon Macs without needing separate distributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mac build configuration to support universal architecture across all build targets
  * Set minimum macOS version requirement to 14.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->